### PR TITLE
Handle null like values and remove deprecated function usage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -5,7 +5,7 @@ on:
     pull_request: ~
 
 env:
-    PHP_VERSION: 8.2
+    PHP_VERSION: 8.3
 
 jobs:
     psalm:

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v5
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -23,7 +23,7 @@ jobs:
 
             -   name: Cache Composer packages
                 id: composer-cache
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: vendor
                     key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
@@ -41,7 +41,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v5
 
             -   name: Setup PHP
                 uses: shivammathur/setup-php@v2
@@ -51,7 +51,7 @@ jobs:
 
             -   name: Cache Composer packages
                 id: composer-cache
-                uses: actions/cache@v2
+                uses: actions/cache@v4
                 with:
                     path: vendor
                     key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -30,8 +30,9 @@ jobs:
                     restore-keys: |
                         ${{ runner.os }}-php-
 
-            -   name: Download dependencies
-                uses: ramsey/composer-install@v1
+            -   name: Install dependencies
+                if: steps.composer-cache.outputs.cache-hit != 'true'
+                run: composer install --prefer-dist --no-progress --no-scripts
 
             -   name: Run Psalm
                 run: ./vendor/bin/psalm --show-info=true --output-format=github --config=psalm.xml --threads=2
@@ -58,8 +59,9 @@ jobs:
                     restore-keys: |
                         ${{ runner.os }}-php-
 
-            -   name: Download dependencies
-                uses: ramsey/composer-install@v1
+            -   name: Install dependencies
+                if: steps.composer-cache.outputs.cache-hit != 'true'
+                run: composer install --prefer-dist --no-progress --no-scripts
 
             -   name: Run PHPCS
                 run: ./vendor/bin/phpcs --report=checkstyle -q ./vendor/bin/phpcs --exclude=Generic.Files.LineLength,PSR1.Files.SideEffects --standard=PSR12 --colors ./src ./tests | cs2pr

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -12,7 +12,7 @@ jobs:
             fail-fast: false
             matrix:
                 operating-system: [ ubuntu-latest ]
-                php: [ '7.4', '8.2' ]
+                php: [ '8.3' ]
 
         steps:
             -   uses: actions/checkout@master

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -21,10 +21,11 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: ${{ matrix.php }}
-                    tools: flex
+                    tools: flex, composer
 
-            -   name: Download dependencies
-                uses: ramsey/composer-install@v1
+            -   name: Install dependencies
+                if: steps.composer-cache.outputs.cache-hit != 'true'
+                run: composer install --prefer-dist --no-progress --no-scripts
 
             -   name: Run test suite on PHP ${{ matrix.php }}
                 run: ./vendor/bin/phpunit

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ There are ways around it using twig - the [documentation](https://twig.symfony.c
 >
 > `{{ post.published_at is empty ? "" : post.published_at|date("m/d/Y") }}`
 
-But often, this is overlooked.
+But often, this is overlooked leading to erroneous information being displayed.
 
 ## Requirements
 
-* PHP >=7.4 or >= 8.2
-* Twig ^3.0
+* PHP = ^8.3
+* Twig ^3.10
 
 ## Installation & Usage
 

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     }
   ],
   "require" : {
-    "php" : ">=7.4||>=8.2",
-    "twig/twig" : "^3.0"
+    "php" : ">=8.3",
+    "twig/twig" : "^3.10"
   },
   "autoload" : {
     "psr-4" : {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Integration">
-            <directory suffix="Test.php">./tests/Integration</directory>
-        </testsuite>
-
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Integration">
+      <directory suffix="Test.php">./tests/Integration</directory>
+    </testsuite>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+  </php>
 </phpunit>

--- a/src/TwigSafeDateExtension.php
+++ b/src/TwigSafeDateExtension.php
@@ -26,23 +26,14 @@ class TwigSafeDateExtension extends AbstractExtension
         ];
     }
 
-    /**
-     * @param Environment $env
-     * @param mixed       $date
-     * @param null        $format
-     * @param null        $timezone
-     * @param string      $contentIfNull
-     *
-     * @return string
-     */
     public function safeDateFormatFilter(
         Environment $env,
-        $date,
-        $format = null,
-        $timezone = null,
+        mixed $date,
+        ?string $format = null,
+        ?string $timezone = null,
         string $contentIfNull = '-'
     ): string {
-        if ($date === null) {
+        if (empty($date)) {
             return $contentIfNull;
         }
 

--- a/src/TwigSafeDateExtension.php
+++ b/src/TwigSafeDateExtension.php
@@ -46,8 +46,10 @@ class TwigSafeDateExtension extends AbstractExtension
             return $contentIfNull;
         }
 
+        $coreExtension = $env->getExtension(CoreExtension::class);
+
         if (null === $format) {
-            $formats = $env->getExtension(CoreExtension::class)->getDateFormat();
+            $formats = $coreExtension->getDateFormat();
 
             $format = $date instanceof DateInterval ? $formats[1] : $formats[0];
         }
@@ -56,6 +58,6 @@ class TwigSafeDateExtension extends AbstractExtension
             return $date->format($format);
         }
 
-        return twig_date_converter($env, $date, $timezone)->format($format);
+        return $coreExtension->formatDate($date, $format, $timezone);
     }
 }

--- a/tests/Integration/TwigSafeDateExtensionTest.php
+++ b/tests/Integration/TwigSafeDateExtensionTest.php
@@ -32,6 +32,8 @@ class TwigSafeDateExtensionTest extends TestCase
     {
         return [
             ['{{ "2016-10-25"|date("d/m/Y", "Europe/London") }}', '25/10/2016'],
+            ['{{ ""|date("d/m/Y") }}', '-'],
+            ['{{ false|date("d/m/Y") }}', '-'],
             ['{{ null|date("d/m/Y") }}', '-'],
             ['{{ null|date("d/m/Y", "Europe/London", "*") }}', '*'],
         ];


### PR DESCRIPTION
Fixes 

- [ADHOC-3500] user deprecated since twig/twig 3.9 using the internal twig date converter function is deprecated
- [ADHOC-3871] Update `vivait/twig-safe-date` to handle null-like values